### PR TITLE
Add adjustments based on feedback, add Linestring selection animation, take line accidents into account for new RWS data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
             title="Rijkswaterstaat"
             filePath="./accidents-excel/RWS-accidents-new.xlsx"
             zoom={7}
-            opacityLevel={4}
+            opacityLevel={5}
             weight={0.1}
           />
         </WidgetWrapper>

--- a/src/components/riskmap/AccidentLocationList.tsx
+++ b/src/components/riskmap/AccidentLocationList.tsx
@@ -63,7 +63,11 @@ const AccidentLocationList: React.FC<AccidentLocationListProps> = ({
                 ? location["Laatste eindtijd"].toTimeString()
                 : ""
             }
-            color={location["Points"] ? "orange" : "red"}
+            color={
+              location["Hmp tot"] && !isNaN(location["Hmp tot"])
+                ? "orange"
+                : "red"
+            }
             Proces={location.Proces}
             Melder={location.Melder}
           />

--- a/src/components/riskmap/RiskMap.tsx
+++ b/src/components/riskmap/RiskMap.tsx
@@ -73,7 +73,7 @@ const RiskMap = ({
     Array<AccidentData>
   >([]);
   const [heatmapVisible, setHeatmapVisible] = useState(true);
-  const [pointsVisible, setPointsVisible] = useState(true);
+  const [pointsVisible, setPointsVisible] = useState(false);
 
   const directionOptions = ["L", "R", "Both"];
   const [selectedDirections, setSelectedDirections] = useState<string[]>([
@@ -229,6 +229,12 @@ const RiskMap = ({
         data: geoJSONDataSegment as GeoJSON.FeatureCollection,
       });
       map.addLayer(accidentsLayerSegmentLayer as AnyLayer);
+
+      if (pointsVisible) {
+        setVisibility(dataLayers, "visible");
+      } else {
+        setVisibility(dataLayers, "none");
+      }
 
       // const geoJSONDataHeatmapLeft = JSON.parse(JSON.stringify(geoJSONDataHeatmap)) as GeoJSON.FeatureCollection
       // geoJSONDataHeatmapLeft.features = geoJSONDataHeatmapLeft.features.filter(feature => feature.properties?.zijde === 'L')

--- a/src/components/riskmap/featureCollectionConverter.ts
+++ b/src/components/riskmap/featureCollectionConverter.ts
@@ -11,8 +11,8 @@ const segmentCoordinates = (data: AccidentData) => {
       coordinates.push(points);
     });
   } else {
-    coordinates.push([data["Latitude_van"], data["Longitude_van"]]);
-    coordinates.push([data["Latitude_tot"], data["Longitude_tot"]]);
+    coordinates.push([data["Longitude_van"], data["Latitude_van"]]);
+    coordinates.push([data["Longitude_tot"], data["Latitude_tot"]]);
   }
   return coordinates;
 };
@@ -83,13 +83,14 @@ const featureCollectionConverter = (dataArray: Array<AccidentData>) => {
   dataArray.forEach((x) => {
     if (x["Points"] !== undefined && x["Points"] !== "")
       featureCollectionSegment.features.push(convertToFeature(x, "LineString"));
-    else if (
-      x["Longitude_tot"] !== -1 &&
-      (x["Longitude_van"] !== x["Longitude_tot"] ||
-        x["Latitude_van"] !== x["Latitude_tot"])
-    )
-      featureCollectionSegment.features.push(convertToFeature(x, "LineString"));
+    // else if (
+    //   x["Longitude_tot"] !== -1 &&
+    //   (x["Longitude_van"] !== x["Longitude_tot"] ||
+    //     x["Latitude_van"] !== x["Latitude_tot"])
+    // )
+    //   featureCollectionSegment.features.push(convertToFeature(x, "LineString"));
     else featureCollectionPoint.features.push(convertToFeature(x, "Point"));
+    // For the heatmap, all features need to be points
     fullFeatureCollection.features.push(convertToFeature(x, "Point"));
   });
 

--- a/src/components/riskmap/layers/accidentsLayerPointLayer.json
+++ b/src/components/riskmap/layers/accidentsLayerPointLayer.json
@@ -1,12 +1,12 @@
 {
-    "id": "accidentsLayerPoint",
-    "type": "circle",
-    "source": "accidentsLocationsSourcePoint",
-    "layout": {},
-    "paint": {
-      "circle-color": "red",
-      "circle-radius": 6,
-      "circle-stroke-color": "#FFF",
-      "circle-stroke-width": 2
-    }
+  "id": "accidentsLayerPoint",
+  "type": "circle",
+  "source": "accidentsLocationsSourcePoint",
+  "layout": {},
+  "paint": {
+    "circle-color": "red",
+    "circle-radius": 2,
+    "circle-stroke-color": "#FFF",
+    "circle-stroke-width": 1
   }
+}

--- a/src/components/riskmap/layers/accidentsLayerSegmentLayer.json
+++ b/src/components/riskmap/layers/accidentsLayerSegmentLayer.json
@@ -1,11 +1,11 @@
 {
-    "id": "accidentsLayerSegment",
-    "type": "line",
-    "source": "accidentsLocationsSourceSegment",
-    "layout": {},
-    "paint": {
-      "line-color": "orange",
-      "line-width": 3,
-      "line-opacity": 1
-    }
+  "id": "accidentsLayerSegment",
+  "type": "line",
+  "source": "accidentsLocationsSourceSegment",
+  "layout": {},
+  "paint": {
+    "line-color": "orange",
+    "line-width": 2,
+    "line-opacity": 1
   }
+}

--- a/src/components/riskmap/useSelectAccident.ts
+++ b/src/components/riskmap/useSelectAccident.ts
@@ -17,6 +17,13 @@ export const selectAccidentAction = (
     }
   });
 
+  map?.on("click", "accidentsLayerSegment", function (e) {
+    if (e.features) {
+      const feature = e.features[0];
+      dispatch(updateSelectedAccidentID(String(feature?.properties?.gid)));
+    }
+  });
+
   changeMousePointers("accidentsLayerPoint", map);
 };
 
@@ -29,18 +36,36 @@ export const useSelectAccident = (
   );
 
   useEffect(() => {
-    if (map && map.getLayer("accidentsLayerPoint") && selectedAccidentID) {
-      map!.setPaintProperty("accidentsLayerPoint", "circle-radius", [
-        "case",
-        ["==", ["get", "gid"], selectedAccidentID],
-        10,
-        6,
-      ]);
+    if (
+      map &&
+      map.getLayer("accidentsLayerPoint") &&
+      map.getLayer("accidentsLayerSegment") &&
+      selectedAccidentID
+    ) {
+      if (map.getLayer("accidentsLayerPoint"))
+        map!.setPaintProperty("accidentsLayerPoint", "circle-radius", [
+          "case",
+          ["==", ["get", "gid"], selectedAccidentID],
+          6,
+          2,
+        ]);
       map!.setPaintProperty("accidentsLayerPoint", "circle-stroke-color", [
         "case",
         ["==", ["get", "gid"], selectedAccidentID],
         "yellow",
         "#FFF",
+      ]);
+      map!.setPaintProperty("accidentsLayerSegment", "line-width", [
+        "case",
+        ["==", ["get", "gid"], selectedAccidentID],
+        5,
+        2,
+      ]);
+      map!.setPaintProperty("accidentsLayerSegment", "line-color", [
+        "case",
+        ["==", ["get", "gid"], selectedAccidentID],
+        "yellow",
+        "orange",
       ]);
       map!.flyTo({
         center: (


### PR DESCRIPTION
- Made the accident points smaller
- Toggled the "show points" button as false by default
- Added animation for clicking on a linestring (available in Brabant data)
- Made some changes to incorporate the linestrings from the new RWS data. This is mostly commented out for now however, as we don't have enough data points on the frontend to show the accident and it generates inconsistencies like such:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/6d8c2eb7-2b75-4018-93e8-b3f4b956e75f">
